### PR TITLE
Load apis

### DIFF
--- a/axion/app.py
+++ b/axion/app.py
@@ -1,15 +1,36 @@
+from pathlib import Path
 import typing as t
 
+from aiohttp import web
+from aiohttp import web_app
+from loguru import logger
 import typing_extensions as te
+import yarl
 
 from axion import spec
+from axion.spec import model
+
+APIs = t.Dict[str, web.Application]
+
+
+class DuplicateBasePath(ValueError):
+    ...
+
+
+class OverlappingBasePath(ValueError):
+    ...
+
+
+class AxionConfiguration(te.TypedDict):
+    ...
 
 
 @te.final
 class Application:
     __slots__ = (
-        'spec',
-        'spec_location',
+        'root_dir',
+        'root_app',
+        'api_base_paths',
     )
 
     @classmethod
@@ -21,7 +42,145 @@ class Application:
 
     def __init__(
             self,
-            spec_location: spec.SpecLocation,
+            root_dir: Path,
+            axion_conf: AxionConfiguration = None,
+            logging_conf: t.Dict[str, t.Any] = None,
     ) -> None:
-        self.spec = spec.load(spec_location)
-        self.spec_location = spec_location
+        self.root_dir = root_dir.resolve()
+        self.root_app = web.Application()
+        # track down API base paths
+        # if there is a try to add an API with the base path
+        # that has been already added suggest adding all APIs
+        # with unique base paths
+        self.api_base_paths = set()  # type: t.Set[str]
+
+    def add_api(
+            self,
+            spec_location: spec.SpecLocation,
+            base_path: t.Optional[str] = None,
+            middlewares: t.Optional[t.Sequence[web_app._Middleware]] = None,
+    ) -> None:
+        if not spec_location.is_absolute():
+            spec_location = (self.root_dir / spec_location).resolve()
+
+        loaded_spec = spec.load(spec_location)
+        target_app, target_base_path = _get_target_app(
+            root_app=self.root_app,
+            known_base_paths=self.api_base_paths,
+            servers=loaded_spec.servers,
+            middlewares=middlewares,
+            base_path=base_path,
+        )
+        self.api_base_paths.add(target_base_path)
+
+        _apply_specification(
+            for_app=target_app,
+            specification=loaded_spec,
+        )
+
+
+def _apply_specification(
+        for_app: web.Application,
+        specification: model.OASSpecification,
+) -> None:
+    for op_key, op_operation in specification.operations.items():
+        for_app.router.add_route(
+            path=op_key.path,
+            method=op_key.http_method.value,
+            name=op_operation.operation_id,
+            handler=get_handler(op_operation),
+        )
+
+
+def _get_target_app(
+        root_app: web.Application,
+        known_base_paths: t.Set[str],
+        servers: t.List[model.OASServer],
+        middlewares: t.Optional[t.Sequence[web_app._Middleware]] = None,
+        base_path: t.Optional[str] = None,
+) -> t.Tuple[web.Application, str]:
+    the_base_path = _get_base_path(
+        servers=servers,
+        base_path=base_path,
+    )
+
+    def check_overlapping() -> bool:
+        for known_base_path in known_base_paths:
+            if known_base_path.startswith(the_base_path):
+                return True
+            elif the_base_path.startswith(known_base_path):
+                return True
+        return False
+
+    if the_base_path in known_base_paths:
+        raise DuplicateBasePath((
+            f'You tried to add API with base_path={the_base_path}, '
+            f'but it is already added. '
+            f'If you want to add more than one API, you will need to '
+            f'specify unique base paths for each API. '
+            f'You can do this either via OAS\'s "servers" property or '
+            f'base_path argument of this function.'
+        ))
+    elif check_overlapping():
+        raise OverlappingBasePath((
+            f'You tried to add API with base_path={the_base_path}, '
+            f'but it is overlapping one of the APIs that has been already added. '
+            f'You need to make sure that base paths for all APIs do '
+            f'not overlap each other.'
+        ))
+    elif the_base_path == '/':
+        logger.debug('Having base_path == / means returning root application')
+        return root_app, the_base_path
+    else:
+        logger.opt(lazy=True).debug(
+            'Detected base_path == {base_path}, making a sub application',
+            base_path=lambda: the_base_path,
+        )
+        nested_app = web.Application(middlewares=middlewares or ())
+        root_app.add_subapp(
+            prefix=the_base_path,
+            subapp=nested_app,
+        )
+        return nested_app, the_base_path
+
+
+def _get_base_path(
+        servers: t.List[model.OASServer],
+        base_path: t.Optional[str] = None,
+) -> str:
+    the_base_path: str
+
+    if base_path:
+        logger.debug(
+            'Using user provided base path = {base_path}',
+            base_path=base_path,
+        )
+        the_base_path = base_path
+    else:
+        server_count = len(servers)
+        if server_count > 1:
+            logger.warning(
+                (
+                    'There are {count} servers, axion will assume first one. '
+                    'This behavior might change in the future, once axion knows '
+                    'how to deal with multiple servers'
+                ),
+                count=len(servers),
+            )
+        first_server = servers[0]
+        logger.debug(
+            'Computing base path using server definition = {server}',
+            server=first_server,
+        )
+        the_base_path = yarl.URL(first_server.url.format(**first_server.variables)).path
+
+    logger.info(
+        'API base path will be {base_path}',
+        base_path=the_base_path,
+    )
+
+    return the_base_path
+
+
+def get_handler(operation: model.Operation) -> web_app._Handler:
+    ...

--- a/axion/app.py
+++ b/axion/app.py
@@ -83,13 +83,7 @@ def _apply_specification(
         for_app: web.Application,
         specification: model.OASSpecification,
 ) -> None:
-    for op_key, op_operation in specification.operations.items():
-        for_app.router.add_route(
-            path=op_key.path,
-            method=op_key.http_method.value,
-            name=op_operation.operation_id,
-            handler=get_handler(op_operation),
-        )
+    ...
 
 
 def _get_target_app(
@@ -180,7 +174,3 @@ def _get_base_path(
     )
 
     return the_base_path
-
-
-def get_handler(operation: model.Operation) -> web_app._Handler:
-    ...

--- a/axion/app.py
+++ b/axion/app.py
@@ -83,7 +83,7 @@ def _apply_specification(
         for_app: web.Application,
         specification: model.OASSpecification,
 ) -> None:
-    ...
+    ...  # pragma: no cover
 
 
 def _get_target_app(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ dataclasses==0.6 ; python_version < '3.7'
 yarl==1.3.0
 pydantic==0.32.1
 typing-extensions==3.7.4
+aiohttp==3.5.4

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -58,7 +58,7 @@ def test_app_multiple_add_apis(
     spec_two.servers = [model.OASServer(url=server_url, variables={})]
     spec_two_path = tmp_path / 'openapi_2.yml'
 
-    def spec_load_side_effect(path: Path) -> ptm.Mock:
+    def spec_load_side_effect(path: Path) -> t.Any:
         return spec_one if path == spec_one_path else spec_two
 
     spec_load = mocker.patch(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,22 +1,180 @@
 from pathlib import Path
+import typing as t
 
 import pytest
 import pytest_mock as ptm
 
 from axion import app
+from axion.spec import model
 
 
-def test_app_init(mocker: ptm.MockFixture, tmp_path: Path) -> None:
+def test_app_init(
+        mocker: ptm.MockFixture,
+        tmp_path: Path,
+) -> None:
+    single_server = model.OASServer(
+        url='/',
+        variables={},
+    )
     loaded_spec = mocker.stub()
-    spec_load = mocker.patch('axion.spec.load', return_value=loaded_spec)
+    loaded_spec.servers = [single_server]
+
+    spec_load = mocker.patch(
+        'axion.spec.load',
+        return_value=loaded_spec,
+    )
+    apply_spec = mocker.patch('axion.app._apply_specification')
+
     spec_location = tmp_path / 'openapi.yaml'
 
-    the_app = app.Application(spec_location=spec_location)
+    the_app = app.Application(root_dir=Path.cwd())
+    the_app.add_api(spec_location)
 
     spec_load.assert_called_once_with(spec_location)
+    apply_spec.assert_called_once_with(
+        for_app=the_app.root_app,
+        specification=loaded_spec,
+    )
 
-    assert the_app.spec == loaded_spec
-    assert the_app.spec_location == spec_location
+    assert the_app.root_dir == Path.cwd()
+    assert len(the_app.root_app._subapps) == 0
+    assert len(the_app.api_base_paths) == 1
+
+
+@pytest.mark.parametrize(
+    'server_url',
+    ('/', '/v1', '/api'),
+)
+def test_app_multiple_add_apis(
+        server_url: str,
+        mocker: ptm.MockFixture,
+        tmp_path: Path,
+) -> None:
+    spec_one = mocker.Mock()
+    spec_one.servers = [model.OASServer(url=server_url, variables={})]
+    spec_one_path = tmp_path / 'openapi_1.yml'
+
+    spec_two = mocker.Mock()
+    spec_two.servers = [model.OASServer(url=server_url, variables={})]
+    spec_two_path = tmp_path / 'openapi_2.yml'
+
+    def spec_load_side_effect(path: Path) -> ptm.Mock:
+        return spec_one if path == spec_one_path else spec_two
+
+    spec_load = mocker.patch(
+        'axion.spec.load',
+        side_effect=spec_load_side_effect,
+    )
+    apply_spec = mocker.patch('axion.app._apply_specification')
+
+    the_app = app.Application(root_dir=Path.cwd())
+    the_app.add_api(spec_one_path)
+    with pytest.raises(app.DuplicateBasePath):
+        the_app.add_api(spec_two_path)
+
+    spec_load.assert_any_call(spec_one_path)
+    spec_load.assert_any_call(spec_two_path)
+
+    if server_url == '/':
+        apply_spec.assert_called_once_with(
+            for_app=the_app.root_app,
+            specification=spec_one,
+        )
+    else:
+        # if we are adding onto the different base path
+        # and there's a duplicate assume that last added
+        # app got the proper load
+        apply_spec.assert_called_once_with(
+            for_app=the_app.root_app._subapps[-1],
+            specification=spec_one,
+        )
+
+
+def test_app_overlapping_base_paths(
+        mocker: ptm.MockFixture,
+        tmp_path: Path,
+) -> None:
+    spec_one = mocker.Mock()
+    spec_one.servers = [model.OASServer(url='/', variables={})]
+    spec_one_path = tmp_path / 'openapi_1.yml'
+
+    spec_two = mocker.Mock()
+    spec_two.servers = [model.OASServer(url='/v1', variables={})]
+    spec_two_path = tmp_path / 'openapi_2.yml'
+
+    def spec_load_side_effect(path: Path) -> t.Any:
+        return spec_one if path == spec_one_path else spec_two
+
+    spec_load = mocker.patch(
+        'axion.spec.load',
+        side_effect=spec_load_side_effect,
+    )
+    apply_spec = mocker.patch('axion.app._apply_specification')
+
+    the_app = app.Application(root_dir=Path.cwd())
+    the_app.add_api(spec_one_path)
+    with pytest.raises(app.OverlappingBasePath):
+        the_app.add_api(spec_two_path)
+
+    spec_load.assert_any_call(spec_one_path)
+    spec_load.assert_any_call(spec_two_path)
+
+    apply_spec.assert_called_once_with(
+        for_app=the_app.root_app,
+        specification=spec_one,
+    )
+
+
+def _test_app_build_routes() -> None:
+    spec_location = Path('tests/specifications/complex.yml')
+    the_app = app.Application(root_dir=Path.cwd())
+    the_app.add_api(spec_location)
+
+
+@pytest.mark.parametrize(('url', 'variables', 'expected_base_path'), (
+    (
+        '/',
+        {},
+        '/',
+    ),
+    (
+        'https://example.org/',
+        {},
+        '/',
+    ),
+    (
+        '/v{api_version}',
+        {
+            'api_version': '1',
+        },
+        '/v1',
+    ),
+    (
+        'https://example.org/v{api_version}',
+        {
+            'api_version': '1',
+        },
+        '/v1',
+    ),
+    (
+        '{protocol}://example.org:{port}/v{api_version}',
+        {
+            'api_version': '1',
+            'port': '443',
+            'protocol': 'https',
+        },
+        '/v1',
+    ),
+))
+def test_app_get_base_path(
+        url: str,
+        variables: t.Dict[str, str],
+        expected_base_path: str,
+) -> None:
+    assert expected_base_path == app._get_base_path(
+        servers=[model.OASServer(url=url, variables=variables)],
+        base_path=None,
+    ) == expected_base_path
 
 
 def test_app_no_override() -> None:


### PR DESCRIPTION
- read servers to make a base path
- ensure that either base paths per APIs are unique
- ensure that base paths do not overlap each other

Fixes #40 