### PR TITLE
Use @functools.cached_property for Handler

### DIFF
--- a/axion/app.py
+++ b/axion/app.py
@@ -111,7 +111,7 @@ def _make_handler(operation: specification.OASOperation) -> web_app._Handler:
     user_handler = application.resolve_handler(operation)
 
     async def handler(request: web.Request) -> web.StreamResponse:
-        await user_handler.fn()  # pragma: no cover
+        await user_handler.fn  # pragma: no cover
         return web.Response()  # pragma: no cover
 
     return handler

--- a/axion/application/handler.py
+++ b/axion/application/handler.py
@@ -46,7 +46,7 @@ else:
 
 
 @te.final
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=True)
 class Handler:
     fn: F
     has_body: bool

--- a/axion/application/handler.py
+++ b/axion/application/handler.py
@@ -38,12 +38,11 @@ BODY_EXPECTED_TYPES = [
     t.Dict[str, t.Any],
 ]
 
-
 if sys.version_info >= (3, 8):
     cached_property = functools.cached_property
 else:
     from cached_property import cached_property
-    
+
 
 @te.final
 class Handler(t.NamedTuple):

--- a/axion/application/handler.py
+++ b/axion/application/handler.py
@@ -45,19 +45,19 @@ class Handler(t.NamedTuple):
     has_body: bool
     param_mapping: ParamMapping
 
-    @property
+    @functools.cached_property
     def path_params(self) -> t.FrozenSet[t.Tuple[str, str]]:
         return self._params('path')
 
-    @property
+    @functools.cached_property
     def header_params(self) -> t.FrozenSet[t.Tuple[str, str]]:
         return self._params('header')
 
-    @property
+    @functools.cached_property
     def query_params(self) -> t.FrozenSet[t.Tuple[str, str]]:
         return self._params('query')
 
-    @property
+    @functools.cached_property
     def cookie_params(self) -> t.FrozenSet[t.Tuple[str, str]]:
         return self._params('cookie')
 

--- a/axion/application/handler.py
+++ b/axion/application/handler.py
@@ -39,25 +39,31 @@ BODY_EXPECTED_TYPES = [
 ]
 
 
+is sys.version_info >= (3, 8):
+    cached_property = functools.cached_property
+else:
+    from cached_property import cached_property
+    
+
 @te.final
 class Handler(t.NamedTuple):
     fn: F
     has_body: bool
     param_mapping: ParamMapping
 
-    @functools.cached_property
+    @cached_property
     def path_params(self) -> t.FrozenSet[t.Tuple[str, str]]:
         return self._params('path')
 
-    @functools.cached_property
+    @cached_property
     def header_params(self) -> t.FrozenSet[t.Tuple[str, str]]:
         return self._params('header')
 
-    @functools.cached_property
+    @cached_property
     def query_params(self) -> t.FrozenSet[t.Tuple[str, str]]:
         return self._params('query')
 
-    @functools.cached_property
+    @cached_property
     def cookie_params(self) -> t.FrozenSet[t.Tuple[str, str]]:
         return self._params('cookie')
 

--- a/axion/application/handler.py
+++ b/axion/application/handler.py
@@ -39,7 +39,7 @@ BODY_EXPECTED_TYPES = [
 ]
 
 
-is sys.version_info >= (3, 8):
+if sys.version_info >= (3, 8):
     cached_property = functools.cached_property
 else:
     from cached_property import cached_property

--- a/axion/application/handler.py
+++ b/axion/application/handler.py
@@ -19,7 +19,7 @@ __all__ = (
     'make',
 )
 
-F = t.Callable[..., t.Awaitable[t.Any]]
+F = t.Callable[..., t.Coroutine[t.Any, t.Any, t.Any]]
 T = t.Any
 
 OAS_Param = t.NamedTuple(

--- a/axion/application/handler.py
+++ b/axion/application/handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+from dataclasses import dataclass
 import functools
 import importlib
 import re
@@ -45,7 +46,8 @@ else:
 
 
 @te.final
-class Handler(te.TypedDict):
+@dataclass(frozen=True)
+class Handler:
     fn: F
     has_body: bool
     param_mapping: ParamMapping

--- a/axion/application/handler.py
+++ b/axion/application/handler.py
@@ -45,7 +45,7 @@ else:
 
 
 @te.final
-class Handler(t.NamedTuple):
+class Handler(te.TypedDict):
     fn: F
     has_body: bool
     param_mapping: ParamMapping

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ dataclasses==0.6 ; python_version < '3.7'
 yarl==1.4.2
 pydantic==1.3
 aiohttp==3.6.2
+cached-property==1.5.1 ; python_version < '3.8'
 
 # typings
 typing-extensions==3.7.4.1

--- a/tests/test_application_handler.py
+++ b/tests/test_application_handler.py
@@ -323,7 +323,7 @@ class TestCookies:
             next(filter(lambda op: op.id == 'no_cookies_op', self.operations)),
         )
 
-        assert hdrl.fn is foo
+        assert id(hdrl.fn) == id(foo)
         assert not hdrl.cookie_params
         assert 'No "cookies" in signature and operation parameters' in caplog.messages
 
@@ -380,7 +380,7 @@ class TestCookies:
             'or typing_extensions.TypedDict[str, typing.Any].'
         )
 
-        assert hdrl.fn is foo
+        assert id(hdrl.fn) == id(foo)
         assert not hdrl.cookie_params
         assert msg in caplog.messages
 
@@ -410,7 +410,7 @@ class TestCookies:
             next(filter(lambda op: op.id == 'cookies_op', self.operations)),
         )
 
-        assert hdrl.fn is foo
+        assert id(hdrl.fn) == id(foo)
         assert hdrl.cookie_params
 
         assert ('csrftoken', 'csrftoken') in hdrl.cookie_params
@@ -533,7 +533,7 @@ class TestCookies:
             next(filter(lambda op: op.id == 'cookies_op', self.operations)),
         )
 
-        assert hdrl.fn is foo
+        assert id(hdrl.fn) == id(foo)
         assert hdrl.cookie_params
         assert len(hdrl.cookie_params) == 2
         assert ('csrftoken', 'csrftoken') in hdrl.cookie_params
@@ -651,7 +651,7 @@ class TestHeaders:
             next(filter(lambda op: op.id == op_id, self.operations)),
         )
 
-        assert hdrl.fn is foo
+        assert id(hdrl.fn) == id(foo)
         assert hdrl.header_params
         msg = (
             'Detected usage of "headers" declared as typing.Any. '
@@ -715,7 +715,7 @@ class TestHeaders:
             'or typing_extensions.TypedDict[str, typing.Any].'
         )
 
-        assert hdrl.fn is foo
+        assert id(hdrl.fn) == id(foo)
         assert not hdrl.header_params
         assert msg in caplog.messages
 
@@ -731,7 +731,7 @@ class TestHeaders:
             next(filter(lambda op: op.id == 'no_headers_op', self.operations)),
         )
 
-        assert hdrl.fn is foo
+        assert id(hdrl.fn) == id(foo)
         assert not hdrl.header_params
         assert 'No "headers" in signature and operation parameters' in caplog.messages
 
@@ -747,7 +747,7 @@ class TestHeaders:
             next(filter(lambda op: op.id == 'no_headers_op', self.operations)),
         )
 
-        assert hdrl.fn is foo
+        assert id(hdrl.fn) == id(foo)
         assert hdrl.header_params
 
         assert ('accept', 'accept') in hdrl.header_params
@@ -832,7 +832,7 @@ class TestHeaders:
                 next(filter(lambda op: op.id == 'no_headers_op', self.operations)),
             )
 
-            assert hdrl.fn is fn
+            assert id(hdrl.fn) == id(fn)
             assert hdrl.header_params
 
             if fn is content_type:
@@ -868,7 +868,7 @@ class TestHeaders:
         operation = next(filter(lambda op: op.id == 'headers_op', self.operations))
         hdrl = handler._build(foo, operation)
 
-        assert hdrl.fn is foo
+        assert id(hdrl.fn) == id(foo)
         assert hdrl.header_params
 
         assert ('accept', 'accept') in hdrl.header_params
@@ -915,7 +915,7 @@ class TestHeaders:
         for fn in (one, two, three, full):
             hdrl = handler._build(fn, operation)
 
-            assert hdrl.fn is fn
+            assert id(hdrl.fn) == id(fn)
             assert hdrl.header_params
 
             if fn is one:


### PR DESCRIPTION
`Handler` is consider `final` classes therefore accessing params should not result in computing results all the time. They should be computed once and kept cached.