### PR TITLE
Execute tests over entire root dir

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
   mkdir -p {toxinidir}/test-reports
 
   py{36,37,38,39}: coverage erase
-  py{36,37,38,39}: pytest tests --junitxml=test-reports/junit.{envname}.xml --cov=axion
+  py{36,37,38,39}: pytest --junitxml=test-reports/junit.{envname}.xml --cov=axion
 
   cov: coverage combine
   cov: coverage xml


### PR DESCRIPTION
Needed to properly enable tests for `mypy` plugin.