### PR TITLE
Enable oas_mypy typing tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -7,5 +7,11 @@ addopts =
     -q
     --tb=native
     --cache-clear
+    --mypy-same-process
+    --mypy-ini-file=typesafety/mypy.ini
+    --mypy-extension-hook=typesafety.test_hook.hook
+testpaths =
+    tests/
+    typesafety/
 log_level = DEBUG
 norecursedirs = *.egg .eggs dist build docs .tox .git __pycache__ .mypy_cache

--- a/tests/test_handler_analysis_path_query_arg.py
+++ b/tests/test_handler_analysis_path_query_arg.py
@@ -120,7 +120,7 @@ def test_signature_mismatch_bad_type() -> None:
 def test_signature_all_bad_type() -> None:
     async def foo(
             id: float,
-            limit: t.Optional[t.Union[int, float]],
+            limit: t.Optional[t.Union[float, int]],
             page: t.Optional[t.AbstractSet[bool]],
             include_extra: t.Union[int, str],
     ) -> response.Response:

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,11 @@ deps =
   -r{toxinidir}/requirements/yapf.txt
 commands =
   find ./ -type f -name '*.pyc' -delete
-  yapf --diff --recursive {toxinidir}/axion {toxinidir}/tests {toxinidir}/setup.py
+  yapf --diff --recursive \
+    {toxinidir}/axion \
+    {toxinidir}/tests \
+    {toxinidir}/typesafety \
+    {toxinidir}/setup.py
 
 [testenv:flake8]
 description = Validates codebase with flake
@@ -48,7 +52,11 @@ deps =
   -r{toxinidir}/requirements/flake8.txt
 commands =
   find ./ -type f -name '*.pyc' -delete
-  flake8 --config {toxinidir}/.flake8 {toxinidir}/axion {toxinidir}/tests {toxinidir}/setup.py
+  flake8 --config {toxinidir}/.flake8 \
+    {toxinidir}/axion \
+    {toxinidir}/tests \
+    {toxinidir}/typesafety \
+    {toxinidir}/setup.py
 
 [testenv:mypy]
 description = Validates codebase with flake
@@ -66,6 +74,7 @@ commands =
     --no-incremental \
     {toxinidir}/axion \
     {toxinidir}/tests \
+    {toxinidir}/typesafety \
     {toxinidir}/setup.py
 
 [testenv:safety]

--- a/typesafety/mypy.ini
+++ b/typesafety/mypy.ini
@@ -1,6 +1,3 @@
 [mypy]
 show_error_codes = True
 ignore_missing_imports = True
-
-[axion-mypy]
-axion_quiet = true

--- a/typesafety/mypy.ini
+++ b/typesafety/mypy.ini
@@ -1,0 +1,6 @@
+[mypy]
+show_error_codes = True
+ignore_missing_imports = True
+
+[axion-mypy]
+axion_quiet = true

--- a/typesafety/test_hook.py
+++ b/typesafety/test_hook.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from pytest_mypy.item import YamlTestItem
+
+
+def hook(test_item: YamlTestItem) -> None:
+    axion_dir = Path(test_item.base_ini_fpath).parents[1]
+
+    plugin_path = (axion_dir / 'axion' / 'oas_mypy' / '__init__.py').resolve()
+    oas_specifications_path = Path.cwd().resolve()
+
+    oas_spec = test_item.parsed_test_data.get('oas_spec', None)
+    if oas_spec:
+        spec_path = Path(oas_specifications_path / f'{test_item.name}.spec.yml')
+        with spec_path.open('w') as handler:
+            handler.write(oas_spec)
+
+    additional_mypy_config = """
+        [mypy]
+        plugins = {plugin_path}
+        [axion-mypy]
+        oas_directories = {oas_specifications_path}
+    """.format(
+        plugin_path=plugin_path,
+        oas_specifications_path=oas_specifications_path,
+    )
+    test_item.additional_mypy_config = additional_mypy_config


### PR DESCRIPTION
Commit makes it possible to run unit tests
against `oas_mypy` plugin.

Pulled-from: #246