### PR TITLE
[TYPING] Add tests for axion.Application

### DIFF
--- a/axion/oas_mypy/app_ctor_analyzer.py
+++ b/axion/oas_mypy/app_ctor_analyzer.py
@@ -22,9 +22,9 @@ def hook(f_ctx: FunctionContext) -> Type:
         err_ctx = f_ctx.context
         err_ctx.line = f_ctx.args[plugin_id_idx][0].line
 
-        f_ctx.api.fail(
+        f_ctx.api.msg.fail(
             f'{plugin_id} is not axion plugin',
-            ctx=err_ctx,
+            context=err_ctx,
             code=errors.ERROR_UNKNOWN_PLUGIN,
         )
 

--- a/typesafety/test_axion_app.yml
+++ b/typesafety/test_axion_app.yml
@@ -1,0 +1,55 @@
+---
+- case: axion_init_aiohttp
+  main: |
+    from pathlib import Path
+    from axion import Axion, Configuration
+
+    Axion(
+      Path.cwd(),
+      'aiohttp',
+      configuration=Configuration(),
+    )
+- case: axion_unkown_plugin
+  main: |
+    from pathlib import Path
+    from axion import Axion, Configuration
+
+    Axion(
+      Path.cwd(),
+      'LOKI',  # E: LOKI is not axion plugin  [axion-no-plugin]
+      configuration=Configuration(),
+    )
+- case: axion_custom_plugin
+  main: |
+    from pathlib import Path
+    from axion import Axion, Configuration
+
+    import thor_app
+
+    app = Axion(
+      Path.cwd(),
+      'cool',
+      configuration=Configuration(),
+    )
+  files:
+    - path: thor_app/__init__.py
+      content: |
+        from thor_app import plugin
+
+        ThorAppPlugin = plugin.CoolPlugin
+
+        __all__ = ('ThorAppPlugin', )
+    - thor_app/plugin.py:
+      content: |
+        import typing_extensions as te
+
+        from axion import Plugin
+
+        @te.final
+        class CoolPlugin(
+          Plugin,
+          id='cool',
+          version='0.1.2',
+        ):
+          """CoolPluginTest. """
+          ...


### PR DESCRIPTION
Partially: #189 
Summary:
- tests `axion.Application` construction site.
- verifies if `id` of a plugin matches those known by `axion`.