### PR TITLE
Enable&Disable logger

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,12 @@ def caplog(caplog: _logging.LogCaptureFixture) -> _logging.LogCaptureFixture:
         def emit(self, record: logging.LogRecord) -> None:
             logging.getLogger(record.name).handle(record)
 
+    logger.enable('axion')
+
     logger.add(
         LoguruHandler(),
         format='{message}',
     )
     yield caplog
+
+    logger.disable('axion')


### PR DESCRIPTION
- enables logger before test case is run
- disables it afterwards

It is required because tests ran inside of `typesafety/` relies
on an output of `mypy` and any output coming from `axion` is then
undesirable and, therefore, treated as white-noise.

Needed-By: #263 
Partially: #189 