### PR TITLE
Ignore coverage in typesafety/ folder

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -14,5 +14,6 @@ exclude_lines =
 ignore_errors = True
 omit =
     tests/*
+    typesafety/*
     .tox/*
     axion/oas_mypy/*


### PR DESCRIPTION
Similarly to `tests/*`, coverage should not be tracked over inside of `typesafety/*`