### PR TITLE
[TYPING] add tests for default values

### DIFF
--- a/axion/oas_mypy/__init__.py
+++ b/axion/oas_mypy/__init__.py
@@ -174,16 +174,14 @@ def _oas_handler_analyzer(
             if oas_default_values:
                 default_matches = handler_arg_default_value in oas_default_values
                 if not default_matches:
-                    _oas_handler_msg(
-                        f_ctx.api.msg.fail,
-                        f_ctx,
-                        (
-                            errors.ERROR_INVALID_OAS_VALUE,
+                    errors.invalid_default_value(
+                        msg=(
                             f'[{f_name}({f_param} -> {oas_param.name})] '
                             f'Incorrect default value. '
                             f'Expected one of {",".join(map(str, oas_default_values))} '
-                            f'but got {handler_arg_default_value}',
+                            f'but got {handler_arg_default_value}'
                         ),
+                        ctx=f_ctx,
                         line_number=handler_arg_type.line,
                     )
                     continue
@@ -195,24 +193,19 @@ def _oas_handler_analyzer(
                         None,
                         f'[{f_name}({f_param} -> {oas_param.name})] '
                         f'OAS does not define a default value. '
-                        f'A default value of "{handler_arg_default_value}" '
-                        f'should be placed in OAS '
-                        f'{oas.parameter_in(oas_param)} {oas_param.name} parameter '
-                        f'under "default" key '
-                        f'given there is an attempt of defining it outside of the OAS.',
+                        f'If you want "{handler_arg_default_value}" to be '
+                        f'defeault value, declare it in OAS.',
                     ),
                     line_number=handler_arg_type.line,
                 )
         elif oas_default_values:
-            _oas_handler_msg(
-                f_ctx.api.msg.fail,
-                f_ctx,
-                (
-                    errors.ERROR_INVALID_OAS_VALUE,
+            errors.invalid_default_value(
+                msg=(
                     f'[{f_name}({f_param} -> {oas_param.name})] OAS '
-                    f'defines "{oas_default_values[0]}" as a '
-                    f'default value. It should be reflected in argument default value.',
+                    f'defines "{",".join(map(str, oas_default_values))}" as a '
+                    f'default value. It should be reflected in argument default value.'
                 ),
+                ctx=f_ctx,
                 line_number=handler_arg_type.line,
             )
             continue

--- a/axion/oas_mypy/errors.py
+++ b/axion/oas_mypy/errors.py
@@ -76,3 +76,18 @@ def invalid_default_value(
     )
 
     return ctx.default_return_type
+
+
+def default_value_not_in_oas(
+        msg: str,
+        ctx: FunctionContext,
+        line_number: Optional[int] = None,
+) -> None:
+    context = ctx.context
+    context.line = line_number or context.line
+
+    ctx.api.msg.note(
+        msg,
+        context=context,
+        code=ERROR_INVALID_OAS_VALUE,
+    )

--- a/axion/oas_mypy/errors.py
+++ b/axion/oas_mypy/errors.py
@@ -59,3 +59,20 @@ def invalid_argument(
     )
 
     return ctx.default_return_type
+
+
+def invalid_default_value(
+        msg: str,
+        ctx: FunctionContext,
+        line_number: Optional[int] = None,
+) -> Type:
+    context = ctx.context
+    context.line = line_number or context.line
+
+    ctx.api.msg.fail(
+        msg,
+        context=context,
+        code=ERROR_INVALID_OAS_VALUE,
+    )
+
+    return ctx.default_return_type

--- a/typesafety/test_default_values.yml
+++ b/typesafety/test_default_values.yml
@@ -1,0 +1,183 @@
+---
+- case: default_not_equal
+  oas_spec: |
+    openapi: 3.0.1
+    info:
+      title: title
+      version: 1.0.0
+    servers:
+      - url: /
+    paths:
+      /:
+        get:
+          operationId: main.default_not_equal
+          parameters:
+            - name: argA
+              in: query
+              schema:
+                type: integer
+                format: int64
+                default: 3
+            - name: argB
+              in: query
+              schema:
+                type: string
+                default: 'argB'
+            - name: argC
+              in: query
+              schema:
+                type: number
+                default: 66.6
+            - name: argD
+              in: query
+              schema:
+                type: boolean
+                default: false
+          responses:
+            default:
+              description: unexpected error
+  main: |
+    import typing as t
+    from axion import oas_endpoint
+    from axion import response
+
+    @oas_endpoint
+    async def default_not_equal(
+      arg_a: int=4,
+      arg_b: str='arg_b',
+      arg_c: float=77.7,
+      arg_d: bool=true,
+    ) -> response.Response:
+      return {}
+  out: |
+    main:7: error: [default_not_equal(arg_a -> argA)] Incorrect default value. Expected 3 but got 4  [axion-arg-value]
+    main:8: error: [default_not_equal(arg_b -> argB)] Incorrect default value. Expected argB but got arg_b  [axion-arg-value]
+    main:9: error: [default_not_equal(arg_c -> argC)] Incorrect default value. Expected 66.6 but got 77.7  [axion-arg-value]
+    main:10: error: [default_not_equal(arg_d -> argD)] Incorrect default value. Expected false but got true  [axion-arg-value]
+- case: default_not_in_oas
+  oas_spec: |
+    openapi: 3.0.1
+    info:
+      title: title
+      version: 1.0.0
+    servers:
+      - url: /
+    paths:
+      /:
+        get:
+          operationId: main.default_not_in_oas
+          parameters:
+            - name: argA
+              in: query
+              required: true
+              schema:
+                type: integer
+                format: int64
+            - name: argB
+              in: query
+              required: true
+              schema:
+                type: string
+          responses:
+            default:
+              description: unexpected error
+  main: |
+    import typing as t
+    from axion import oas_endpoint
+    from axion import response
+
+    @oas_endpoint
+    async def default_not_in_oas(
+      arg_a: int=100,
+      arg_b: str='test',
+    ) -> response.Response:
+      return {}
+  out: |
+    main:7: note: [default_not_in_oas(arg_a -> argA)] OAS does not define a default value. If you want "100" to be default value, declare it in OAS.
+    main:8: note: [default_not_in_oas(arg_b -> argB)] OAS does not define a default value. If you want "test" to be default value, declare it in OAS.
+- case: default_not_in_handler_required
+  oas_spec: |
+    openapi: 3.0.1
+    info:
+      title: title
+      version: 1.0.0
+    servers:
+      - url: /
+    paths:
+      /:
+        get:
+          operationId: main.d
+          parameters:
+            - name: argA
+              in: query
+              required: true
+              schema:
+                type: integer
+                format: int64
+                default: 100
+            - name: argB
+              in: query
+              required: true
+              schema:
+                type: string
+                default: argB
+          responses:
+            default:
+              description: unexpected error
+  main: |
+    import typing as t
+    from axion import oas_endpoint
+    from axion import response
+
+    @oas_endpoint
+    async def d(
+      arg_a: int,
+      arg_b: str,
+    ) -> response.Response:
+      return {}
+  out: |
+    main:7: error: [default_not_in_handler(arg_a -> argA)] OAS defines "100" as a default value. It should be reflected in argument default value.  [axion-arg-value]
+    main:8: error: [default_not_in_handler(arg_b -> argB)] OAS defines "argB" as a default value. It should be reflected in argument default value.  [axion-arg-value]
+- case: default_not_in_handler_not_required
+  oas_spec: |
+    openapi: 3.0.1
+    info:
+      title: title
+      version: 1.0.0
+    servers:
+      - url: /
+    paths:
+      /:
+        get:
+          operationId: main.f
+          parameters:
+            - name: argA
+              in: query
+              required: false
+              schema:
+                type: integer
+                format: int64
+                default: 100
+            - name: argB
+              in: query
+              required: false
+              schema:
+                type: string
+                default: argB
+          responses:
+            default:
+              description: unexpected error
+  main: |
+    import typing as t
+    from axion import oas_endpoint
+    from axion import response
+
+    @oas_endpoint
+    async def f(
+      arg_a: t.Optional[int],
+      arg_b: t.Optional[str],
+    ) -> response.Response:
+      return {}
+  out: |
+    main:7: error: [default_not_in_handler(arg_a -> argA)] OAS defines "100" as a default value. It should be reflected in argument default value.  [axion-arg-value]
+    main:8: error: [default_not_in_handler(arg_b -> argB)] OAS defines "argB" as a default value. It should be reflected in argument default value.  [axion-arg-value]

--- a/typesafety/test_default_values.yml
+++ b/typesafety/test_default_values.yml
@@ -198,8 +198,8 @@
     ) -> response.Response:
       return {}
   out: |
-    main:7: error: [default_not_in_handler(arg_a -> argA)] OAS defines "100" as a default value. It should be reflected in argument default value.  [axion-arg-value]
-    main:8: error: [default_not_in_handler(arg_b -> argB)] OAS defines "argB" as a default value. It should be reflected in argument default value.  [axion-arg-value]
+    main:7: error: [d(arg_a -> argA)] OAS defines "100" as a default value. It should be reflected in argument default value.  [axion-arg-value]
+    main:8: error: [d(arg_b -> argB)] OAS defines "argB" as a default value. It should be reflected in argument default value.  [axion-arg-value]
 - case: default_not_in_handler_not_required
   oas_spec: |
     openapi: 3.0.1
@@ -241,8 +241,8 @@
     ) -> response.Response:
       return {}
   out: |
-    main:7: error: [default_not_in_handler(arg_a -> argA)] OAS defines "100" as a default value. It should be reflected in argument default value.  [axion-arg-value]
-    main:8: error: [default_not_in_handler(arg_b -> argB)] OAS defines "argB" as a default value. It should be reflected in argument default value.  [axion-arg-value]
+    main:7: error: [f(arg_a -> argA)] OAS defines "100" as a default value. It should be reflected in argument default value.  [axion-arg-value]
+    main:8: error: [f(arg_b -> argB)] OAS defines "argB" as a default value. It should be reflected in argument default value.  [axion-arg-value]
 - case: nullable_handling
   oas_spec: |
     openapi: 3.0.1

--- a/typesafety/test_default_values.yml
+++ b/typesafety/test_default_values.yml
@@ -1,4 +1,66 @@
 ---
+- case: correct_example
+  oas_spec: |
+    openapi: 3.0.1
+    info:
+      title: title
+      version: 1.0.0
+    servers:
+      - url: /
+    paths:
+      /:
+        get:
+          operationId: main.ce
+          parameters:
+            - name: argA
+              in: query
+              schema:
+                type: integer
+                default: 3
+            - name: argB
+              in: query
+              schema:
+                type: string
+                default: 'argB'
+            - name: argC
+              in: query
+              schema:
+                type: number
+                default: 66.6
+            - name: argD
+              in: query
+              schema:
+                type: boolean
+                default: false
+            - name: argE
+              in: query
+              required: false
+              schema:
+                type: boolean
+            - name: argF
+              in: query
+              required: false
+              schema:
+                type: boolean
+                nullable: true
+          responses:
+            default:
+              description: unexpected error
+  main: |
+    import typing as t
+    from axion import oas_endpoint
+    from axion import response
+
+    @oas_endpoint
+    async def default_not_equal(
+      arg_a: int=3,
+      arg_b: str='argB',
+      arg_c: float=66.6,
+      arg_d: bool=false,
+      arg_e: t.Optional[bool]=None,
+      arg_f: t.Optional[bool]=None,
+    ) -> response.Response:
+      return {}
 - case: default_not_equal
   oas_spec: |
     openapi: 3.0.1
@@ -181,3 +243,44 @@
   out: |
     main:7: error: [default_not_in_handler(arg_a -> argA)] OAS defines "100" as a default value. It should be reflected in argument default value.  [axion-arg-value]
     main:8: error: [default_not_in_handler(arg_b -> argB)] OAS defines "argB" as a default value. It should be reflected in argument default value.  [axion-arg-value]
+- case: nullable_handling
+  oas_spec: |
+    openapi: 3.0.1
+    info:
+      title: title
+      version: 1.0.0
+    servers:
+      - url: /
+    paths:
+      /:
+        get:
+          operationId: main.f
+          parameters:
+            - name: argA
+              in: query
+              nullable: true
+              schema:
+                type: integer
+            - name: argB
+              in: query
+              required: true
+              nullable: true
+              schema:
+                type: number
+                default: 10.0
+          responses:
+            default:
+              description: unexpected error
+  main: |
+    import typing as t
+    from axion import oas_endpoint
+    from axion import response
+
+    @oas_endpoint
+    async def f(
+      arg_a: t.Optional[int]=None,
+      arg_b: t.Optional[float]=11.0,
+    ) -> response.Response:
+      return {}
+  out: |
+    main:8: error: [default_not_equal(arg_b -> argB)] Incorrect default value. Expected 10.0 but got 11.0  [axion-arg-value]

--- a/typesafety/test_default_values.yml
+++ b/typesafety/test_default_values.yml
@@ -29,6 +29,7 @@
                 default: 66.6
             - name: argD
               in: query
+              required: true
               schema:
                 type: boolean
                 default: false
@@ -48,15 +49,16 @@
               description: unexpected error
   main: |
     import typing as t
+
     from axion import oas_endpoint
     from axion import response
 
     @oas_endpoint
-    async def default_not_equal(
+    async def ce(
       arg_a: int=3,
       arg_b: str='argB',
       arg_c: float=66.6,
-      arg_d: bool=false,
+      arg_d: bool=False,
       arg_e: t.Optional[bool]=None,
       arg_f: t.Optional[bool]=None,
     ) -> response.Response:
@@ -108,14 +110,14 @@
       arg_a: int=4,
       arg_b: str='arg_b',
       arg_c: float=77.7,
-      arg_d: bool=true,
+      arg_d: bool=True,
     ) -> response.Response:
       return {}
   out: |
     main:7: error: [default_not_equal(arg_a -> argA)] Incorrect default value. Expected 3 but got 4  [axion-arg-value]
     main:8: error: [default_not_equal(arg_b -> argB)] Incorrect default value. Expected argB but got arg_b  [axion-arg-value]
     main:9: error: [default_not_equal(arg_c -> argC)] Incorrect default value. Expected 66.6 but got 77.7  [axion-arg-value]
-    main:10: error: [default_not_equal(arg_d -> argD)] Incorrect default value. Expected false but got true  [axion-arg-value]
+    main:10: error: [default_not_equal(arg_d -> argD)] Incorrect default value. Expected False but got True  [axion-arg-value]
 - case: default_not_in_oas
   oas_spec: |
     openapi: 3.0.1

--- a/typesafety/test_default_values.yml
+++ b/typesafety/test_default_values.yml
@@ -44,6 +44,12 @@
               schema:
                 type: boolean
                 nullable: true
+            - name: argG
+              in: query
+              required: true
+              schema:
+                type: boolean
+                nullable: true
           responses:
             default:
               description: unexpected error
@@ -61,6 +67,7 @@
       arg_d: bool=False,
       arg_e: t.Optional[bool]=None,
       arg_f: t.Optional[bool]=None,
+      arg_g: t.Optional[bool]=None,
     ) -> response.Response:
       return {}
 - case: default_not_equal
@@ -142,11 +149,17 @@
               required: true
               schema:
                 type: string
+            - name: argC
+              in: query
+              required: true
+              schema:
+                type: boolean
           responses:
             default:
               description: unexpected error
   main: |
     import typing as t
+
     from axion import oas_endpoint
     from axion import response
 
@@ -154,11 +167,13 @@
     async def default_not_in_oas(
       arg_a: int=100,
       arg_b: str='test',
+      arg_c: bool=False,
     ) -> response.Response:
       return {}
   out: |
-    main:7: note: [default_not_in_oas(arg_a -> argA)] OAS does not define a default value. If you want "100" to be default value, declare it in OAS.
-    main:8: note: [default_not_in_oas(arg_b -> argB)] OAS does not define a default value. If you want "test" to be default value, declare it in OAS.
+    main:8: note: [default_not_in_oas(arg_a -> argA)] OAS does not define a default value. If you want "100" to be consistent default value, it should be declared in OAS too.
+    main:9: note: [default_not_in_oas(arg_b -> argB)] OAS does not define a default value. If you want "test" to be consistent default value, it should be declared in OAS too.
+    main:10: note: [default_not_in_oas(arg_c -> argC)] OAS does not define a default value. If you want "False" to be consistent default value, it should be declared in OAS too.
 - case: default_not_in_handler_required
   oas_spec: |
     openapi: 3.0.1
@@ -260,21 +275,22 @@
           parameters:
             - name: argA
               in: query
-              nullable: true
               schema:
                 type: integer
+                nullable: true
             - name: argB
               in: query
               required: true
-              nullable: true
               schema:
                 type: number
                 default: 10.0
+                nullable: true
           responses:
             default:
               description: unexpected error
   main: |
     import typing as t
+
     from axion import oas_endpoint
     from axion import response
 
@@ -285,4 +301,4 @@
     ) -> response.Response:
       return {}
   out: |
-    main:8: error: [default_not_equal(arg_b -> argB)] Incorrect default value. Expected 10.0 but got 11.0  [axion-arg-value]
+    main:9: error: [f(arg_b -> argB)] Incorrect default value. Expected 10.0 but got 11.0  [axion-arg-value]

--- a/typesafety/test_default_values.yml
+++ b/typesafety/test_default_values.yml
@@ -271,7 +271,7 @@
     paths:
       /:
         get:
-          operationId: main.f
+          operationId: main.nh
           parameters:
             - name: argA
               in: query
@@ -295,10 +295,10 @@
     from axion import response
 
     @oas_endpoint
-    async def f(
+    async def nh(
       arg_a: t.Optional[int]=None,
       arg_b: t.Optional[float]=11.0,
     ) -> response.Response:
       return {}
   out: |
-    main:9: error: [f(arg_b -> argB)] Incorrect default value. Expected 10.0 but got 11.0  [axion-arg-value]
+    main:9: error: [nh(arg_b -> argB)] Incorrect default value. Expected 10.0 but got 11.0  [axion-arg-value]


### PR DESCRIPTION
Partially: #189 
From: #246 

axion will validate how `python` default values on handler's arguments play with corresponding `OAS` arguments.