### PR TITLE
Remove Python 3.6 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
             EOF
       - restore_cache:
           keys:
-            - pyenv-v7-{{ arch }}
+            - pyenv-v8-{{ arch }}
       - run:
           name: Install Pythons
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,8 @@ jobs:
             EOF
       - restore_cache:
           keys:
-            - pyenv-v8-{{ arch }}
+            - pyenv-v9-{{ arch }}
+            - tox-v0-{{ arch }}
       - run:
           name: Install Pythons
           command: |
@@ -60,10 +61,14 @@ jobs:
             pyenv install 3.8.4 -s
             pyenv install 3.9-dev -s
       - save_cache:
-          key: pyenv-v8-{{ arch }}
+          key: pyenv-v9-{{ arch }}
           paths:
             - ~/.pyenv/versions/3.7.8
             - ~/.pyenv/versions/3.8.4
+      - save_cache:
+          key: tox-v0-{{ arch }}
+          paths:
+            - .tox
       - run:
           name: Mighty test run
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
   verify:
     working_directory: ~/app
     docker:
-      - image: circleci/python:3.8.3
+      - image: circleci/python:3.8.4
     steps:
       - checkout
       - <<: *install_prepare
@@ -27,7 +27,7 @@ jobs:
   verify_examples:
     working_directory: ~/app
     docker:
-      - image: circleci/python:3.8.3
+      - image: circleci/python:3.8.4
     steps:
       - checkout
       - <<: *install_prepare
@@ -36,7 +36,7 @@ jobs:
           command: tox -e mypy_examples
   test:
     docker:
-      - image: circleci/python:3.8.3
+      - image: circleci/python:3.8.4
     working_directory: ~/app
     steps:
       - checkout
@@ -56,21 +56,19 @@ jobs:
           name: Install Pythons
           command: |
             eval "$(pyenv init -)"
-            pyenv install 3.6.10 -s
-            pyenv install 3.7.7 -s
-            pyenv install 3.8.3 -s
+            pyenv install 3.7.8 -s
+            pyenv install 3.8.4 -s
             pyenv install 3.9-dev -s
       - save_cache:
-          key: pyenv-v7-{{ arch }}
+          key: pyenv-v8-{{ arch }}
           paths:
-            - ~/.pyenv/versions/3.6.10
-            - ~/.pyenv/versions/3.7.7
-            - ~/.pyenv/versions/3.8.3
+            - ~/.pyenv/versions/3.7.8
+            - ~/.pyenv/versions/3.8.4
       - run:
           name: Mighty test run
           command: |
             eval "$(pyenv init -)"
-            pyenv shell 3.6.10 3.7.7 3.8.3 3.9-dev
+            pyenv shell 3.7.8 3.8.4 3.9-dev
             tox
       - store_test_results:
           path: test-reports
@@ -83,7 +81,7 @@ jobs:
           when: on_success
   install:
     docker:
-      - image: circleci/python:3.8.3
+      - image: circleci/python:3.8.4
     working_directory: ~/app
     steps:
       - checkout
@@ -100,7 +98,7 @@ jobs:
 
   deploy:
     docker:
-      - image: circleci/python:3.8.3
+      - image: circleci/python:3.8.4
     working_directory: ~/app
     steps:
       - checkout

--- a/axion/handler/analysis/cookies_arg.py
+++ b/axion/handler/analysis/cookies_arg.py
@@ -127,8 +127,9 @@ def _signature_set_oas_set(
 
                 oas_param = next(
                     filter(
-                        lambda p: p.name == param_cookies[model.
-                                                          get_f_param(cookie_param_name)],
+                        lambda p: p.name == param_cookies[model.get_f_param(
+                            cookie_param_name,
+                        )],
                         parameters,
                     ),
                 )

--- a/axion/handler/analysis/cookies_arg.py
+++ b/axion/handler/analysis/cookies_arg.py
@@ -123,9 +123,6 @@ def _signature_set_oas_set(
     try:
         r_cookies_arg = types.resolve_root_type(cookies_arg)
         entries = t.get_type_hints(r_cookies_arg).items()
-        if not entries:
-            logger.debug('cookies_arg {h} is not dict like', h=r_cookies_arg)
-            raise TypeError('Not a dict like structure')
 
         logger.debug(
             'cookies_arg is {h}:{t} with entries {e}',

--- a/axion/handler/analysis/cookies_arg.py
+++ b/axion/handler/analysis/cookies_arg.py
@@ -120,55 +120,42 @@ def _signature_set_oas_set(
     param_mapping: t.Dict[model.OASParam, model.FunctionArgName] = {}
     param_cookies = {model.get_f_param(rh.name): rh.name for rh in parameters}
 
-    try:
-        entries = t.get_type_hints(cookies_arg).items()
-        if entries:
-            for cookie_param_name, cookie_param_type in entries:
-                if cookie_param_name in param_cookies:
+    entries = t.get_type_hints(cookies_arg).items()
+    for cookie_param_name, cookie_param_type in entries:
+        if cookie_param_name in param_cookies:
 
-                    oas_param = next(
-                        filter(
-                            lambda p: p.name == param_cookies[
-                                model.get_f_param(cookie_param_name)],
-                            parameters,
-                        ),
-                    )
-                    oas_param_type = model.convert_oas_param_to_ptype(oas_param)
-                    if oas_param_type != cookie_param_type:
-                        errors.add(
-                            exceptions.Error(
-                                param_name=f'cookies.{cookie_param_name}',
-                                reason=exceptions.IncorrectTypeReason(
-                                    actual=cookie_param_type,
-                                    expected=[oas_param_type],
-                                ),
-                            ),
-                        )
-                    else:
-                        param_mapping[model.OASParam(
-                            param_in='cookie',
-                            param_name=param_cookies[model.get_f_param(
-                                cookie_param_name,
-                            )],
-                        )] = model.get_f_param(cookie_param_name)
-
-                else:
-                    errors.add(
-                        exceptions.Error(
-                            param_name=f'cookies.{cookie_param_name}',
-                            reason='unknown',
-                        ),
-                    )
-        else:
-            raise TypeError(
-                'Not TypedDict to jump into exception below. '
-                'This is 3.6 compatibility action.',
+            oas_param = next(
+                filter(
+                    lambda p: p.name == param_cookies[
+                        model.get_f_param(cookie_param_name)],
+                    parameters,
+                ),
             )
-    except TypeError:
-        for hdr_param_name, hdr_param_type in param_cookies.items():
-            param_mapping[model.OASParam(
-                param_in='cookie',
-                param_name=hdr_param_type,
-            )] = hdr_param_name
+            oas_param_type = model.convert_oas_param_to_ptype(oas_param)
+            if oas_param_type != cookie_param_type:
+                errors.add(
+                    exceptions.Error(
+                        param_name=f'cookies.{cookie_param_name}',
+                        reason=exceptions.IncorrectTypeReason(
+                            actual=cookie_param_type,
+                            expected=[oas_param_type],
+                        ),
+                    ),
+                )
+            else:
+                param_mapping[model.OASParam(
+                    param_in='cookie',
+                    param_name=param_cookies[model.get_f_param(
+                        cookie_param_name,
+                    )],
+                )] = model.get_f_param(cookie_param_name)
+
+        else:
+            errors.add(
+                exceptions.Error(
+                    param_name=f'cookies.{cookie_param_name}',
+                    reason='unknown',
+                ),
+            )
 
     return errors, param_mapping

--- a/axion/handler/analysis/cookies_arg.py
+++ b/axion/handler/analysis/cookies_arg.py
@@ -121,7 +121,19 @@ def _signature_set_oas_set(
     param_cookies = {model.get_f_param(rh.name): rh.name for rh in parameters}
 
     try:
-        entries = t.get_type_hints(cookies_arg).items()
+        r_cookies_arg = types.resolve_root_type(cookies_arg)
+        entries = t.get_type_hints(r_cookies_arg).items()
+        if not entries:
+            logger.debug('cookies_arg {h} is not dict like', h=r_cookies_arg)
+            raise TypeError('Not a dict like structure')
+
+        logger.debug(
+            'cookies_arg is {h}:{t} with entries {e}',
+            h=r_cookies_arg,
+            t=type(r_cookies_arg),
+            e=entries,
+        )
+
         for cookie_param_name, cookie_param_type in entries:
             if cookie_param_name in param_cookies:
 

--- a/axion/handler/analysis/cookies_arg.py
+++ b/axion/handler/analysis/cookies_arg.py
@@ -126,8 +126,8 @@ def _signature_set_oas_set(
 
             oas_param = next(
                 filter(
-                    lambda p: p.name == param_cookies[
-                        model.get_f_param(cookie_param_name)],
+                    lambda p: p.name == param_cookies[model.
+                                                      get_f_param(cookie_param_name)],
                     parameters,
                 ),
             )

--- a/axion/handler/analysis/headers_arg.py
+++ b/axion/handler/analysis/headers_arg.py
@@ -115,7 +115,19 @@ def _signature_set_oas_gone(
     param_mapping: t.Dict[model.OASParam, model.FunctionArgName] = {}
 
     try:
-        entries = t.get_type_hints(headers_arg).items()
+        r_headers_arg = types.resolve_root_type(headers_arg)
+        entries = t.get_type_hints(r_headers_arg).items()
+        if not entries:
+            logger.debug('headers_arg {h} is not dict like', h=r_headers_arg)
+            raise TypeError('Not a dict like structure')
+
+        logger.debug(
+            'headers_arg is {h}:{t} with entries {e}',
+            h=r_headers_arg,
+            e=entries,
+            t=type(r_headers_arg),
+        )
+
         for hdr_param_name, hdr_param_type in entries:
             if hdr_param_name not in RESERVED_HEADERS:
                 logger.error(
@@ -173,7 +185,19 @@ def _analyze_headers_signature_set_oas_set(
     }
 
     try:
-        entries = t.get_type_hints(headers_arg).items()
+        r_headers_arg = types.resolve_root_type(headers_arg)
+        entries = t.get_type_hints(r_headers_arg).items()
+        if not entries:
+            logger.debug('headers_arg {h} is not dict like', h=r_headers_arg)
+            raise TypeError('Not a dict like structure')
+
+        logger.debug(
+            'headers_arg is {h}:{t} with entries {e}',
+            h=r_headers_arg,
+            t=type(r_headers_arg),
+            e=entries,
+        )
+
         for hdr_param_name, hdr_param_type in entries:
             if hdr_param_name in all_headers_names:
                 # now tricky part, for reserved headers we enforce str

--- a/axion/handler/analysis/headers_arg.py
+++ b/axion/handler/analysis/headers_arg.py
@@ -192,8 +192,9 @@ def _analyze_headers_signature_set_oas_set(
                 elif hdr_param_name in param_headers:
                     oas_param = next(
                         filter(
-                            lambda p: p.name == param_headers[
-                                model.get_f_param(hdr_param_name)],
+                            lambda p: p.name == param_headers[model.get_f_param(
+                                hdr_param_name,
+                            )],
                             parameters,
                         ),
                     )

--- a/axion/handler/analysis/headers_arg.py
+++ b/axion/handler/analysis/headers_arg.py
@@ -114,36 +114,43 @@ def _signature_set_oas_gone(
     errors: t.Set[exceptions.Error] = set()
     param_mapping: t.Dict[model.OASParam, model.FunctionArgName] = {}
 
-    entries = t.get_type_hints(headers_arg).items()
-    for hdr_param_name, hdr_param_type in entries:
-        if hdr_param_name not in RESERVED_HEADERS:
-            logger.error(
-                '{sig_key} is not one of {reserved_headers} headers',
-                sig_key=hdr_param_name,
-                reserved_headers=oas.OASReservedHeaders,
-            )
-            errors.add(
-                exceptions.Error(
-                    param_name=f'headers.{hdr_param_name}',
-                    reason='unknown',
-                ),
-            )
-        elif hdr_param_type != str:
-            errors.add(
-                exceptions.Error(
-                    param_name=f'headers.{hdr_param_name}',
-                    reason=exceptions.IncorrectTypeReason(
-                        actual=hdr_param_type,
-                        expected=[str],
+    try:
+        entries = t.get_type_hints(headers_arg).items()
+        for hdr_param_name, hdr_param_type in entries:
+            if hdr_param_name not in RESERVED_HEADERS:
+                logger.error(
+                    '{sig_key} is not one of {reserved_headers} headers',
+                    sig_key=hdr_param_name,
+                    reserved_headers=oas.OASReservedHeaders,
+                )
+                errors.add(
+                    exceptions.Error(
+                        param_name=f'headers.{hdr_param_name}',
+                        reason='unknown',
                     ),
-                ),
-            )
-        else:
-            param_key = model.get_f_param(hdr_param_name)
+                )
+            elif hdr_param_type != str:
+                errors.add(
+                    exceptions.Error(
+                        param_name=f'headers.{hdr_param_name}',
+                        reason=exceptions.IncorrectTypeReason(
+                            actual=hdr_param_type,
+                            expected=[str],
+                        ),
+                    ),
+                )
+            else:
+                param_key = model.get_f_param(hdr_param_name)
+                param_mapping[model.OASParam(
+                    param_in='header',
+                    param_name=RESERVED_HEADERS[param_key],
+                )] = param_key
+    except TypeError:
+        for hdr_f_name, hdr_name in RESERVED_HEADERS.items():
             param_mapping[model.OASParam(
                 param_in='header',
-                param_name=RESERVED_HEADERS[param_key],
-            )] = param_key
+                param_name=hdr_name.lower(),
+            )] = hdr_f_name
 
     return errors, param_mapping
 

--- a/axion/handler/analysis/headers_arg.py
+++ b/axion/handler/analysis/headers_arg.py
@@ -182,8 +182,8 @@ def _analyze_headers_signature_set_oas_set(
             elif hdr_param_name in param_headers:
                 oas_param = next(
                     filter(
-                        lambda p: p.name == param_headers[
-                            model.get_f_param(hdr_param_name)],
+                        lambda p: p.name == param_headers[model.
+                                                          get_f_param(hdr_param_name)],
                         parameters,
                     ),
                 )

--- a/axion/handler/analysis/headers_arg.py
+++ b/axion/handler/analysis/headers_arg.py
@@ -117,9 +117,6 @@ def _signature_set_oas_gone(
     try:
         r_headers_arg = types.resolve_root_type(headers_arg)
         entries = t.get_type_hints(r_headers_arg).items()
-        if not entries:
-            logger.debug('headers_arg {h} is not dict like', h=r_headers_arg)
-            raise TypeError('Not a dict like structure')
 
         logger.debug(
             'headers_arg is {h}:{t} with entries {e}',
@@ -187,9 +184,6 @@ def _analyze_headers_signature_set_oas_set(
     try:
         r_headers_arg = types.resolve_root_type(headers_arg)
         entries = t.get_type_hints(r_headers_arg).items()
-        if not entries:
-            logger.debug('headers_arg {h} is not dict like', h=r_headers_arg)
-            raise TypeError('Not a dict like structure')
 
         logger.debug(
             'headers_arg is {h}:{t} with entries {e}',

--- a/axion/handler/analysis/headers_arg.py
+++ b/axion/handler/analysis/headers_arg.py
@@ -114,52 +114,36 @@ def _signature_set_oas_gone(
     errors: t.Set[exceptions.Error] = set()
     param_mapping: t.Dict[model.OASParam, model.FunctionArgName] = {}
 
-    try:
-        # deal with typed dict, only reserved headers are allowed as dict
-        entries = t.get_type_hints(headers_arg).items()
-        if entries:
-            for hdr_param_name, hdr_param_type in entries:
-                if hdr_param_name not in RESERVED_HEADERS:
-                    logger.error(
-                        '{sig_key} is not one of {reserved_headers} headers',
-                        sig_key=hdr_param_name,
-                        reserved_headers=oas.OASReservedHeaders,
-                    )
-                    errors.add(
-                        exceptions.Error(
-                            param_name=f'headers.{hdr_param_name}',
-                            reason='unknown',
-                        ),
-                    )
-                elif hdr_param_type != str:
-                    errors.add(
-                        exceptions.Error(
-                            param_name=f'headers.{hdr_param_name}',
-                            reason=exceptions.IncorrectTypeReason(
-                                actual=hdr_param_type,
-                                expected=[str],
-                            ),
-                        ),
-                    )
-                else:
-                    param_key = model.get_f_param(hdr_param_name)
-                    param_mapping[model.OASParam(
-                        param_in='header',
-                        param_name=RESERVED_HEADERS[param_key],
-                    )] = param_key
-        else:
-            raise TypeError(
-                'Not TypedDict to jump into exception below. '
-                'This is 3.6 compatibility action.',
+    entries = t.get_type_hints(headers_arg).items()
+    for hdr_param_name, hdr_param_type in entries:
+        if hdr_param_name not in RESERVED_HEADERS:
+            logger.error(
+                '{sig_key} is not one of {reserved_headers} headers',
+                sig_key=hdr_param_name,
+                reserved_headers=oas.OASReservedHeaders,
             )
-    except TypeError:
-        # deal with mapping: in that case user will receive all
-        # reserved headers inside of the handler
-        for hdr_f_name, hdr_name in RESERVED_HEADERS.items():
+            errors.add(
+                exceptions.Error(
+                    param_name=f'headers.{hdr_param_name}',
+                    reason='unknown',
+                ),
+            )
+        elif hdr_param_type != str:
+            errors.add(
+                exceptions.Error(
+                    param_name=f'headers.{hdr_param_name}',
+                    reason=exceptions.IncorrectTypeReason(
+                        actual=hdr_param_type,
+                        expected=[str],
+                    ),
+                ),
+            )
+        else:
+            param_key = model.get_f_param(hdr_param_name)
             param_mapping[model.OASParam(
                 param_in='header',
-                param_name=hdr_name.lower(),
-            )] = hdr_f_name
+                param_name=RESERVED_HEADERS[param_key],
+            )] = param_key
 
     return errors, param_mapping
 
@@ -179,69 +163,56 @@ def _analyze_headers_signature_set_oas_set(
         **RESERVED_HEADERS,
     }
 
-    try:
-        entries = t.get_type_hints(headers_arg).items()
-        if entries:
-            for hdr_param_name, hdr_param_type in entries:
-                if hdr_param_name in all_headers_names:
-                    # now tricky part, for reserved headers we enforce str
-                    # for oas headers we do type check
-                    if hdr_param_name in RESERVED_HEADERS and hdr_param_type != str:
-                        errors.add(
-                            exceptions.Error(
-                                param_name=f'headers.{hdr_param_name}',
-                                reason=exceptions.IncorrectTypeReason(
-                                    actual=hdr_param_type,
-                                    expected=[str],
-                                ),
-                            ),
-                        )
-                        continue
-                    elif hdr_param_name in param_headers:
-                        oas_param = next(
-                            filter(
-                                lambda p: p.name == param_headers[
-                                    model.get_f_param(hdr_param_name)],
-                                parameters,
-                            ),
-                        )
-                        oas_param_type = model.convert_oas_param_to_ptype(oas_param)
-                        if oas_param_type != hdr_param_type:
-                            errors.add(
-                                exceptions.Error(
-                                    param_name=f'headers.{hdr_param_name}',
-                                    reason=exceptions.IncorrectTypeReason(
-                                        actual=hdr_param_type,
-                                        expected=[str],
-                                    ),
-                                ),
-                            )
-                            continue
-
-                    param_mapping[model.OASParam(
-                        param_in='header',
-                        param_name=all_headers_names[model.get_f_param(
-                            hdr_param_name,
-                        )].lower(),
-                    )] = model.get_f_param(hdr_param_name)
-
-                else:
+    entries = t.get_type_hints(headers_arg).items()
+    for hdr_param_name, hdr_param_type in entries:
+        if hdr_param_name in all_headers_names:
+            # now tricky part, for reserved headers we enforce str
+            # for oas headers we do type check
+            if hdr_param_name in RESERVED_HEADERS and hdr_param_type != str:
+                errors.add(
+                    exceptions.Error(
+                        param_name=f'headers.{hdr_param_name}',
+                        reason=exceptions.IncorrectTypeReason(
+                            actual=hdr_param_type,
+                            expected=[str],
+                        ),
+                    ),
+                )
+                continue
+            elif hdr_param_name in param_headers:
+                oas_param = next(
+                    filter(
+                        lambda p: p.name == param_headers[
+                            model.get_f_param(hdr_param_name)],
+                        parameters,
+                    ),
+                )
+                oas_param_type = model.convert_oas_param_to_ptype(oas_param)
+                if oas_param_type != hdr_param_type:
                     errors.add(
                         exceptions.Error(
                             param_name=f'headers.{hdr_param_name}',
-                            reason='unknown',
+                            reason=exceptions.IncorrectTypeReason(
+                                actual=hdr_param_type,
+                                expected=[str],
+                            ),
                         ),
                     )
-        else:
-            raise TypeError(
-                'Not TypedDict to jump into exception below. '
-                'This is 3.6 compatibility action.',
-            )
-    except TypeError:
-        for hdr_param_name, hdr_param_type in all_headers_names.items():
+                    continue
+
             param_mapping[model.OASParam(
                 param_in='header',
-                param_name=hdr_param_type.lower(),
-            )] = hdr_param_name
+                param_name=all_headers_names[model.get_f_param(
+                    hdr_param_name,
+                )].lower(),
+            )] = model.get_f_param(hdr_param_name)
+
+        else:
+            errors.add(
+                exceptions.Error(
+                    param_name=f'headers.{hdr_param_name}',
+                    reason='unknown',
+                ),
+            )
 
     return errors, param_mapping

--- a/axion/utils/get_type_repr.py
+++ b/axion/utils/get_type_repr.py
@@ -37,7 +37,7 @@ def _repr(val: t.Any) -> str:
         else:
             return 'typing.Any'
     elif ti.is_optional_type(val):
-        optional_args = _ti_get_args(val)[:-1]
+        optional_args = ti.get_args(val, True)[:-1]
         nested_union = len(optional_args) > 1
         optional_reprs = (get_repr(tt) for tt in optional_args)
         if nested_union:
@@ -45,7 +45,7 @@ def _repr(val: t.Any) -> str:
         else:
             return f'typing.Optional[{", ".join(optional_reprs)}]'
     elif ti.is_union_type(val):
-        union_reprs = (get_repr(tt) for tt in _ti_get_args(val))
+        union_reprs = (get_repr(tt) for tt in ti.get_args(val, True))
         return f'typing.Union[{", ".join(union_reprs)}]'
     elif ti.is_generic_type(val):
 
@@ -87,14 +87,3 @@ def _qualified_name(tt: t.Type[t.Any]) -> str:
         the_name = tt.__name__ or tt.__qualname__
 
     return the_name
-
-
-if sys.version_info < (3, 7):
-    logger.trace('python 3.6 detected, using typing_inspect.get_last_args')
-
-    def _ti_get_args(val: t.Any) -> t.Any:
-        return ti.get_last_args(val)
-else:
-
-    def _ti_get_args(val: t.Any) -> t.Any:
-        return ti.get_args(val, True)

--- a/axion/utils/get_type_repr.py
+++ b/axion/utils/get_type_repr.py
@@ -1,4 +1,3 @@
-import sys
 import typing as t
 
 from loguru import logger

--- a/axion/utils/get_type_repr.py
+++ b/axion/utils/get_type_repr.py
@@ -48,19 +48,8 @@ def _repr(val: t.Any) -> str:
         union_reprs = (get_repr(tt) for tt in ti.get_args(val, True))
         return f'typing.Union[{", ".join(union_reprs)}]'
     elif ti.is_generic_type(val):
-
-        if sys.version_info < (3, 7):
-            attr_name = val.__name__
-            generic_reprs = [get_repr(tt) for tt in ti.get_last_args(val)]
-            if not generic_reprs:
-                generic_reprs = (get_repr(tt) for tt in ti.get_parameters(val))
-        else:
-            attr_name = val._name
-            generic_reprs = (get_repr(tt) for tt in ti.get_args(val, evaluate=True))
-
-        assert generic_reprs is not None
-        assert attr_name is not None
-
+        attr_name = val._name
+        generic_reprs = (get_repr(tt) for tt in ti.get_args(val, evaluate=True))
         return f'typing.{attr_name}[{", ".join(generic_reprs)}]'
     else:
         val_name = _qualified_name(val)

--- a/axion/utils/types.py
+++ b/axion/utils/types.py
@@ -70,6 +70,13 @@ def is_dict_like(tt: t.Any) -> bool:
     return False  # pragma: no cover
 
 
+@functools.lru_cache(maxsize=30, typed=True)
+def resolve_root_type(tt: t.Any) -> t.Any:
+    if ti.is_new_type(tt):
+        return resolve_root_type(tt.__supertype__)
+    return tt
+
+
 def literal_types(tt: t.Any) -> t.Iterable[PP]:
     assert ti.is_literal_type(tt)
     pps = [_literal_types(x) for x in ti.get_args(tt, ti.NEW_TYPING)]

--- a/classifiers.txt
+++ b/classifiers.txt
@@ -7,9 +7,9 @@ License :: OSI Approved :: Apache Software License
 Operating System :: OS Independent
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
 Programming Language :: Python :: 3 :: Only
 Topic :: Software Development :: Libraries :: Application Frameworks
 Topic :: Software Development :: User Interfaces

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ __author_email__ = 'kornicameister@gmail.com'
 __maintainer__ = __author__
 __url__ = 'https://github.com/kornicameister/axion'
 
-if sys.version_info < (3, 6):
-    raise RuntimeError(f'{__title__}:{__version__} requires Python 3.6 or greater')
+if sys.version_info < (3, 7):
+    raise RuntimeError(f'{__title__}:{__version__} requires Python 3.7 or greater')
 
 setuptools.setup(
     setup_requires='setupmeta',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     versioning='post',
     package_data={
         'axion': ['py.typed'],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py39}-test,cov
+envlist = {py37,py38,py39}-test,cov
 minversion = 3.11.1
 skipdist = True
 usedevelop = True
@@ -17,14 +17,14 @@ whitelist_externals = bash
                       find
                       mkdir
 setenv=
-    py{36,37,38,39}: COVERAGE_FILE={toxinidir}/.coverage.{envname}
+    py{37,38,39}: COVERAGE_FILE={toxinidir}/.coverage.{envname}
 commands_pre =
   find ./ -type f -name '*.pyc' -delete
 commands =
   mkdir -p {toxinidir}/test-reports
 
-  py{36,37,38,39}: coverage erase
-  py{36,37,38,39}: pytest --junitxml=test-reports/junit.{envname}.xml --cov=axion {posargs}
+  py{37,38,39}: coverage erase
+  py{37,38,39}: pytest --junitxml=test-reports/junit.{envname}.xml --cov=axion {posargs}
 
   cov: coverage combine
   cov: coverage xml


### PR DESCRIPTION
Given how work procedes it is quite possible `axion` will not
reach a place where it can be used with 3.6. After all we have 3.9 closing
in, so why even bother with 3 minor older release.