### PR TITLE
Use xunit2 family for pytest

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -15,3 +15,5 @@ testpaths =
     typesafety/
 log_level = DEBUG
 norecursedirs = *.egg .eggs dist build docs .tox .git __pycache__ .mypy_cache
+
+junit_family = xunit2

--- a/pytest.ini
+++ b/pytest.ini
@@ -17,5 +17,5 @@ log_level = DEBUG
 norecursedirs = *.egg .eggs dist build docs .tox .git __pycache__ .mypy_cache
 
 # junit settings
-junit_logging=log
+junit_logging = log
 junit_family = xunit2

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
   mkdir -p {toxinidir}/test-reports
 
   py{36,37,38,39}: coverage erase
-  py{36,37,38,39}: pytest --junitxml=test-reports/junit.{envname}.xml --cov=axion {posargs}
+  py{36,37,38,39}: pytest --junitxml=test-reports/junit.{envname}.xml --junit_family=xunit2 --cov=axion {posargs}
 
   cov: coverage combine
   cov: coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ commands =
   mkdir -p {toxinidir}/test-reports
 
   py{36,37,38,39}: coverage erase
-  py{36,37,38,39}: pytest --junitxml=test-reports/junit.{envname}.xml --junit_family=xunit2 --cov=axion {posargs}
+  py{36,37,38,39}: pytest --junitxml=test-reports/junit.{envname}.xml --cov=axion {posargs}
 
   cov: coverage combine
   cov: coverage xml


### PR DESCRIPTION
```
Warning: The 'junit_family' default value will change to 'xunit2' in pytest 6.0.
  Add 'junit_family=xunit1' to your pytest.ini file to keep the current format in future versions of pytest and silence this warning.
    _issue_warning_captured(deprecated.JUNIT_XML_DEFAULT_FAMILY, config.hook, 2)
```